### PR TITLE
Typo in README.md

### DIFF
--- a/04.3.4/provider/README.md
+++ b/04.3.4/provider/README.md
@@ -1,3 +1,3 @@
 # Provider
 
-Diese Dateien dienen lediglich der Übersicht. Anhand dieser Beispiele können Sie bei sich in Ihrem Projektverzeichnis z.B. eine `provider.tf` Datei anlegen oder sich das Schema einer `clouds.yaml` Datei anschauen. Sie können sich ebenfalls ein Beispiel für eine `.basrc`-Datei anschauen.
+Diese Dateien dienen lediglich der Übersicht. Anhand dieser Beispiele können Sie bei sich in Ihrem Projektverzeichnis z.B. eine `provider.tf` Datei anlegen oder sich das Schema einer `clouds.yaml` Datei anschauen. Sie können sich ebenfalls ein Beispiel für eine `.bashrc`-Datei anschauen.


### PR DESCRIPTION
.bashrc instead of .basrc