### PR TITLE
Falsche Dateiendung vom Playbook

### DIFF
--- a/07.2.4/Ansible_Playbook/main.tf
+++ b/07.2.4/Ansible_Playbook/main.tf
@@ -3,7 +3,7 @@ resource "null_resource" "ansible-per-local-exec" {
   provisioner "local-exec" {
     command = <<EOL
       export ANSIBLE_HOST_KEY_CHECKING=False;
-      ansible-playbook -u ${var.user} --private-key ${var.ssh_private_key} -i self.public_ip web-playbook.yaml
+      ansible-playbook -u ${var.user} --private-key ${var.ssh_private_key} -i self.public_ip web-playbook.yml
     EOL
   }
 }


### PR DESCRIPTION
Ändert die Dateiendung des Playbooks, welche eigentlich mit `yml` endet.

Vermeidet folgende Fehlermeldung:
```
null_resource.ansible-per-local-exec (local-exec): ERROR! the playbook: web-playbook.yaml could not be found
```
